### PR TITLE
Update the docs for slice_bytearray

### DIFF
--- a/lib/aiken/builtin.ak
+++ b/lib/aiken/builtin.ak
@@ -72,8 +72,8 @@ pub fn cons_bytearray(byte: Int, bytes: ByteArray) -> ByteArray {
   fail
 }
 
-/// Extract a sub-array from a bytearray given starting and ending indexes.
-pub fn slice_bytearray(start: Int, end: Int, bytes: ByteArray) -> ByteArray {
+/// Extract a sub-array from a bytearray given starting index and length of the sub-array
+pub fn slice_bytearray(start: Int, len: Int, bytes: ByteArray) -> ByteArray {
   fail
 }
 


### PR DESCRIPTION
slice_bytearray takes the starting index and length of the sub-array not the end index