### PR TITLE
Fix return type for some builtin methods

### DIFF
--- a/lib/aiken/builtin.ak
+++ b/lib/aiken/builtin.ak
@@ -80,7 +80,7 @@ pub fn equals_integer(left: Int, right: Int) -> Bool {
 /// ---                                   | ---
 ///
 /// Integer strict inequality.
-pub fn less_than_integer(left: Int, right: Int) -> Int {
+pub fn less_than_integer(left: Int, right: Int) -> Bool {
   fail
 }
 
@@ -88,7 +88,7 @@ pub fn less_than_integer(left: Int, right: Int) -> Int {
 /// ---                                   | ---
 ///
 /// Integer inequality.
-pub fn less_than_equals_integer(left: Int, right: Int) -> Int {
+pub fn less_than_equals_integer(left: Int, right: Int) -> Bool {
   fail
 }
 
@@ -188,7 +188,7 @@ pub fn verify_ed25519_signature(
   verification_key: ByteArray,
   message: ByteArray,
   signature: ByteArray,
-) -> ByteArray {
+) -> Bool {
   fail
 }
 
@@ -200,7 +200,7 @@ pub fn verify_ecdsa_secp256k1_signature(
   verification_key: ByteArray,
   message: ByteArray,
   signature: ByteArray,
-) -> ByteArray {
+) -> Bool {
   fail
 }
 
@@ -212,7 +212,7 @@ pub fn verify_schnorr_secp256k1_signature(
   verification_key: ByteArray,
   message: ByteArray,
   signature: ByteArray,
-) -> ByteArray {
+) -> Bool {
   fail
 }
 
@@ -364,7 +364,7 @@ pub fn un_b_data(data: Data) -> ByteArray {
 /// ---                                   | ---
 ///
 /// Equality on Data.
-pub fn equals_data(left: Data, right: Data) -> ByteArray {
+pub fn equals_data(left: Data, right: Data) -> Bool {
   fail
 }
 


### PR DESCRIPTION
Actually `less_than_integer`, `less_than_equals_integer`, `verify_ed25519_signature`, `verify_ecdsa_secp256k1_signature`, `verify_schnorr_secp256k1_signature` and `equals_data` return Bool. Most likely it was just a copy/paste typo